### PR TITLE
docs(loader): Separated docs into multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/brandonroberts/angular2-router-loader.svg?style=shield&circle-token=a8a709588d22664ab74922050eda672898d2d417)](https://circleci.com/gh/brandonroberts/angular2-router-loader)
 [![npm version](https://badge.fury.io/js/angular2-router-loader.svg)](https://badge.fury.io/js/angular2-router-loader)
 
-A Webpack loader for Angular 2 that enables string-based module loading with the `Angular Router`
+A Webpack loader for Angular that enables string-based module loading with the `Angular Router`
 
 ## Installation
 
@@ -49,111 +49,12 @@ export const routes: Routes = [
 ];
 ```
 
-## Loader Options
+## Additional Documentation
 
-Options are provided as a query string with the `angular2-router-loader`
+* [Loader Options](./docs/options.md#general-loader-options)
+* [AoT Compilation Options](./docs/options.md#loader-options-aot-compilation)
 
-```ts
-loaders: [
-  'angular2-router-loader?option=value'
-]
 
-```
-
-### debug: `(default: false)`
-
-Logs the file, loadChildren string found and replacement string used to the console.
-
-### delimiter: `(default: '#')`
-
-Changes to default delimiter for the module path/module name string
-
-### loader: `(default: 'require')`
-
-Sets the loader string returned for code splitting.
-
-original
-```ts
-{
-  path: 'lazy',
-  loadChildren './lazy.module#LazyModule'
-}
-```
-
-replacement
-```ts
-{
-  path: 'lazy',
-  loadChildren: () => new Promise(function (resolve) {
-    (require as any).ensure([], function (require: any) {
-      resolve(require('./lazy/lazy.module')['LazyModule']);
-    });
-  })
-}
-```
-
-If you prefer to use `System.import`, set the `loader` to `system`
-
-**NOTE:** Using `system` only works with Webpack 2. Webpack 1 users should use the default.
-
-replacement
-```ts
-{
-  path: 'lazy',
-  loadChildren: () => System.import('./lazy/lazy.module').then(function(module) {
-    return module['LazyModule'];
-  })
-}
-```
-
-## Loader options (AoT compilation)
-
-### aot: `(default: false)`
-
-Used when bundling from an AoT compilation build.
-
-Enables replacement of the `loadChildren` string to
-load the factory file and factory class based on the provided file and class.
-
-### moduleSuffix `(default: '.ngfactory')`
-
-Sets the suffix added to the filename for the factory file created by the AoT compiler
-
-### factorySuffix `(default: 'NgFactory')`
-
-Sets the class suffix added to the file class for the factory created by the AoT compiler
-
-### genDir `(default: '')`
-
-If you set the `genDir` in the `angularCompilerOptions` to compile to a separate directory, this option needs to be set to the relative path that directory.
-
-## AoT example
-
-```ts
-loaders: [
-  'angular2-router-loader?aot=true'
-]
-```
-
-original
-```ts
-{
-  path: 'lazy',
-  loadChildren './lazy.module#LazyModule'
-}
-```
-
-replacement
-```ts
-{
-  path: 'lazy',
-  loadChildren: () => new Promise(function (resolve) {
-    (require as any).ensure([], function (require: any) {
-      resolve(require('./lazy/lazy.module.ngfactory')['LazyModuleNgFactory']);
-    });
-  })
-}
-```
 
 ## Credits
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,0 +1,113 @@
+## General Loader Options
+
+Options are provided as a query string with the `angular2-router-loader`
+
+```ts
+loaders: [
+  'angular2-router-loader?option=value'
+]
+
+```
+
+### debug: `(default: false)`
+
+Logs the file, loadChildren string found and replacement string used to the console.
+
+### loader: `(default: 'require')`
+
+Sets the loader string returned for code splitting.
+
+original
+```ts
+{
+  path: 'lazy',
+  loadChildren './lazy.module#LazyModule'
+}
+```
+
+replacement
+```ts
+{
+  path: 'lazy',
+  loadChildren: () => new Promise(function (resolve) {
+    (require as any).ensure([], function (require: any) {
+      resolve(require('./lazy/lazy.module')['LazyModule']);
+    });
+  })
+}
+```
+
+If you prefer to use `System.import`, set the `loader` to `system`
+
+**NOTE:** Using `system` only works with Webpack 2. Webpack 1 users should use the default.
+
+replacement
+```ts
+{
+  path: 'lazy',
+  loadChildren: () => System.import('./lazy/lazy.module').then(function(module) {
+    return module['LazyModule'];
+  })
+}
+```
+
+## Loader options (AoT compilation)
+
+### aot: `(default: false)`
+
+Enables replacement of the `loadChildren` string to
+load the Angular compiled factory file and factory class based on the provided file and class.
+
+### genDir `(default: '')`
+
+In your `tsconfig.json`, if you set the `genDir` in the `angularCompilerOptions` to compile to a separate directory, this option needs to be set to the relative path to your application directory.
+
+## AoT example
+
+Example file structure
+```
+|-- src  
+   |-- app  
+|-- tsconfig.json
+```
+tsconfig.json (Angular Compiler Options)
+
+```json
+"angularCompilerOptions": {
+  "genDir": "src/compiled",
+  "skipMetadataEmit" : true
+}
+```
+
+Webpack Configuration (TypeScript loaders)
+```ts
+loaders: [
+  {
+    test: /\.ts$/,
+    loaders: [
+      'awesome-typescript-loader',
+      'angular2-router-loader?aot=true&genDir=src/compiled/src/app'
+    ]
+  }
+]
+```
+
+original
+```ts
+{
+  path: 'lazy',
+  loadChildren './lazy.module#LazyModule'
+}
+```
+
+replacement
+```ts
+{
+  path: 'lazy',
+  loadChildren: () => new Promise(function (resolve) {
+    (require as any).ensure([], function (require: any) {
+      resolve(require('./lazy/lazy.module.ngfactory')['LazyModuleNgFactory']);
+    });
+  })
+}
+```


### PR DESCRIPTION
Improved examples for AoT usage with `genDir`. 

Removed documentation for `delimiter`, `moduleSuffix` and `factorySuffix` as these options are not able to be changed for AoT compilation. The purpose of the loader is to provide a similar syntax that is currently used when lazy loading with a string. These options still exist in the loader source code.
