### PR TITLE
Update utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,7 @@ module.exports.getRequireLoader = function(filePath, moduleName, inline) {
     'loadChildren: () => new Promise(function (resolve) {',
     '  (require as any).ensure([], function (require: any) {',
     '    resolve(' + requireString + ');',
-    '  });',
+    '  }, \'' + this.getFileNameFromFilePath(filePath) + '\');',
     '})'
   ];
 
@@ -41,6 +41,12 @@ module.exports.getSystemLoader = function(filePath, moduleName, inline) {
 
   return inline ? result.join('') : result.join('\n');
 };
+
+module.exports.getFileNameFromFilePath = function(filePath) {
+  var startIndex = filePath.lastIndexOf('/');
+  var endIndex = filePath.indexOf('.module');
+  return filePath.substring((startIndex+1), endIndex);
+}
 
 module.exports.getFilename = function(resourcePath) {
   var filename = path.basename(resourcePath);


### PR DESCRIPTION
Add function 'getFileNameFromFilePath' to extract the file name from the loadChildren path.
Used to set the name of the chunks in the webpack output config: chunkFilename: '[name].chunk.js'.